### PR TITLE
Fix bug in API 25+

### DIFF
--- a/mediapicker/src/main/AndroidManifest.xml
+++ b/mediapicker/src/main/AndroidManifest.xml
@@ -5,4 +5,16 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
+
+    <application>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="vn.tungdx.mediapicker"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths"/>
+        </provider>
+    </application>
 </manifest>

--- a/mediapicker/src/main/java/vn/tungdx/mediapicker/activities/MediaPickerActivity.java
+++ b/mediapicker/src/main/java/vn/tungdx/mediapicker/activities/MediaPickerActivity.java
@@ -19,6 +19,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
@@ -352,7 +353,7 @@ public class MediaPickerActivity extends AppCompatActivity implements
             if (file != null) {
                 mPhotoFileCapture = file;
                 takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT,
-                        Uri.fromFile(file));
+                        FileProvider.getUriForFile(this, "vn.tungdx.mediapicker" , file));
                 startActivityForResult(takePictureIntent, REQUEST_PHOTO_CAPTURE);
                 mFileObserverTask = new FileObserverTask();
                 mFileObserverTask.execute();

--- a/mediapicker/src/main/res/xml/file_provider_paths.xml
+++ b/mediapicker/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
In API 25+ when you take a photo it crash. I add a FileProvider instead of Uri.getFile(file).